### PR TITLE
Fix invalid CLI service templates

### DIFF
--- a/packages/cli/src/templates/service.template.ts
+++ b/packages/cli/src/templates/service.template.ts
@@ -1,29 +1,31 @@
-import { OnDestroy, OnInit } from "@maltyxx/zenject";
-import { injectable } from "tsyringe";
+import { injectable, type OnDestroy, type OnInit } from "@zenject/core";
 
 /**
  * Service for ${SERVICE_NAME} operations
  */
 @injectable()
 export class ${CLASS_NAME} implements OnInit, OnDestroy {
-  constructor() 
+  constructor() {}
 
   /**
    * Lifecycle hook called after instantiation
    */
-  async onInit(): Promise<void> 
-    console.log('${CLASS_NAME} initialized');
+  async onInit(): Promise<void> {
+    console.log("${CLASS_NAME} initialized");
+  }
 
   /**
    * Lifecycle hook called before destruction
    */
-  async onDestroy(): Promise<void> 
-    console.log('${CLASS_NAME} destroyed');
+  async onDestroy(): Promise<void> {
+    console.log("${CLASS_NAME} destroyed");
+  }
 
   /**
    * Example method
    * @returns A sample result
    */
-  getSampleData(): string 
-    return '${SERVICE_NAME} data';
-} 
+  getSampleData(): string {
+    return "${SERVICE_NAME} data";
+  }
+}

--- a/packages/cli/src/templates/service.test.template.ts
+++ b/packages/cli/src/templates/service.test.template.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, beforeEach, afterEach, mock } from "bun:test";
 import { ${CLASS_NAME} } from "./${SERVICE_NAME}.service";
-import { createTestingContainer, createMock } from "@maltyxx/zenject/testing";
-import { AppLifecycle } from "@maltyxx/zenject";
+import { createTestingContainer, createMock } from "@zenject/testing";
+import { AppLifecycle } from "@zenject/core";
 
 describe("${CLASS_NAME}", () => {
-  let service: $CLASS_NAME;
+  let service: ${CLASS_NAME};
   let testContainer;
 
   // Example of mocking a dependency


### PR DESCRIPTION
## Summary
- fix CLI service templates referencing old package scope
- ensure generated service and test use valid TypeScript

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68616cd72a34832e8b46a8240dec3634