### PR TITLE
Add dynamic module and type-helper tests

### DIFF
--- a/packages/core/tests/dynamic-module.test.ts
+++ b/packages/core/tests/dynamic-module.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  AppContainer,
+  type DynamicModule,
+  loadModule,
+  processDynamicModule,
+} from "@zenject/core";
+
+class ServiceA {}
+class ModuleA {}
+
+class ServiceB {}
+class ModuleB {}
+
+describe("processDynamicModule", () => {
+  beforeEach(() => {
+    AppContainer.reset();
+  });
+
+  test("processes and loads a dynamic module", async () => {
+    const dynamic: DynamicModule = {
+      module: ModuleA,
+      providers: [ServiceA],
+      exports: [ServiceA],
+    };
+    processDynamicModule(dynamic);
+    await loadModule(ModuleA);
+    const instance = AppContainer.resolve(ServiceA);
+    expect(instance).toBeInstanceOf(ServiceA);
+  });
+
+  test("registers exports from imported dynamic modules", async () => {
+    const modA: DynamicModule = {
+      module: ModuleA,
+      providers: [ServiceA],
+      exports: [ServiceA],
+    };
+    const modB: DynamicModule = {
+      module: ModuleB,
+      imports: [modA],
+      providers: [ServiceB],
+    };
+    await loadModule(modB);
+    expect(AppContainer.resolve(ServiceA)).toBeInstanceOf(ServiceA);
+    expect(AppContainer.resolve(ServiceB)).toBeInstanceOf(ServiceB);
+  });
+});

--- a/packages/core/tests/type-helpers.test.ts
+++ b/packages/core/tests/type-helpers.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { InjectionToken } from "@zenject/core";
+import { container } from "tsyringe";
+import { isToken, typedResolve } from "../src/utils/type-helpers";
+
+class MyService {
+  public value = 1;
+}
+
+describe("isToken", () => {
+  test("identifies valid tokens", () => {
+    expect(isToken("str")).toBe(true);
+    expect(isToken(Symbol("sym"))).toBe(true);
+    expect(isToken(MyService)).toBe(true);
+    const tok = new InjectionToken("TOK");
+    expect(isToken(tok)).toBe(true);
+  });
+
+  test("returns false for invalid tokens", () => {
+    expect(isToken(null)).toBe(false);
+    expect(isToken({})).toBe(false);
+  });
+});
+
+describe("typedResolve", () => {
+  test("resolves token with correct type", () => {
+    const child = container.createChildContainer();
+    child.register(MyService, { useClass: MyService });
+    const svc = typedResolve(child, MyService);
+    expect(svc).toBeInstanceOf(MyService);
+    expect(svc.value).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests covering `processDynamicModule` and exported providers
- verify helper functions `typedResolve` and `isToken`

## Testing
- `bun run format`
- `bun run lint`
- `bun run typecheck`
- `bun test`
- `bun test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6861b5db281c832ebc7dcd9870d5a17e